### PR TITLE
only use hie flags on ghc >= 8.8

### DIFF
--- a/numhask.cabal
+++ b/numhask.cabal
@@ -36,10 +36,14 @@ source-repository head
 
 library
   hs-source-dirs:           src
+  
   ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wredundant-constraints -fwrite-ide-info
-    -hiedir=.hie
+    -Wincomplete-uni-patterns -Wredundant-constraints 
+    
+  if impl(ghc >= 8.8)
+    ghc-options:       
+      -fwrite-ide-info -hiedir=.hie
 
   x-docspec-extra-packages: QuickCheck
   build-depends:            base >=4.7 && <5


### PR DESCRIPTION
This should fix build errors on 8.6 (which is too old to support the hie flags).